### PR TITLE
Fix compile settings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "svg_report"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 printpdf = "0.7.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,16 +3,16 @@ use std::fs::File;
 use std::io::BufWriter;
 
 // A4 page dimensions in millimeters
-const PAGE_WIDTH: f32 = 210.0;
-const PAGE_HEIGHT: f32 = 297.0;
-const MARGIN: f32 = 10.0;
+const PAGE_WIDTH: f64 = 210.0;
+const PAGE_HEIGHT: f64 = 297.0;
+const MARGIN: f64 = 10.0;
 
 // Font sizes
-const FONT_SIZE_LARGE_TITLE: f32 = 18.;
-const FONT_SIZE_TITLE: f32 = 11.;
-const FONT_SIZE_NORMAL: f32 = 9.;
-const FONT_SIZE_SMALL: f32 = 7.;
-const FONT_SIZE_SYMBOL: f32 = 12.;
+const FONT_SIZE_LARGE_TITLE: f64 = 18.0;
+const FONT_SIZE_TITLE: f64 = 11.0;
+const FONT_SIZE_NORMAL: f64 = 9.0;
+const FONT_SIZE_SMALL: f64 = 7.0;
+const FONT_SIZE_SYMBOL: f64 = 12.0;
 
 fn main() -> Result<(), std::io::Error> {
     // Create a new PDF document


### PR DESCRIPTION
## Summary
- update Rust edition to 2021
- use f64 for measurements and font sizes

## Testing
- `cargo check` *(fails: failed to get `printpdf` as a dependency)*

------
https://chatgpt.com/codex/tasks/task_e_685f423406888325b0ba279de646f6af