### PR TITLE
Center Jane Doe text with exact metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,7 @@ dependencies = [
 name = "svg_report"
 version = "0.1.0"
 dependencies = [
+ "owned_ttf_parser",
  "printpdf",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 printpdf = "0.7.0"
+owned_ttf_parser = "0.19"


### PR DESCRIPTION
## Summary
- use RobotoMedium font to get precise glyph measurements
- calculate exact text dimensions using owned_ttf_parser
- center text within the rounded rectangle
- add owned_ttf_parser dependency

## Testing
- `cargo build --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_685f611e87708325897d94f4c14f9f56